### PR TITLE
Add smart IEx code copy with output-to-comment conversion

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -199,6 +199,40 @@
   background-color: oklch(60% 0.12 184);
 }
 
+/* Copy button tooltip */
+.message-content .copy-button {
+  position: relative;
+}
+
+.message-content .copy-button::after {
+  content: 'Shift+Click for clean code';
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  background-color: oklch(20% 0.01 252);
+  color: oklch(95% 0.01 252);
+  border: 1px solid oklch(45% 0.15 277);
+  border-radius: 0.25rem;
+  font-size: 0.6875rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 20;
+}
+
+[data-theme="light"] .message-content .copy-button::after {
+  background-color: oklch(95% 0.005 252);
+  color: oklch(25% 0.01 252);
+  border-color: oklch(75% 0.05 252);
+}
+
+.message-content .copy-button:hover::after {
+  opacity: 1;
+}
+
 .message-content .reveal-button.revealed {
   background-color: oklch(50% 0.15 340);
 }

--- a/lib/elixir_bear_web/live/chat_live.ex
+++ b/lib/elixir_bear_web/live/chat_live.ex
@@ -655,7 +655,9 @@ defmodule ElixirBearWeb.ChatLive do
                     </div>
                   <% end %>
 
-                  <div class="prose prose-sm max-w-none message-content">{Markdown.to_html(message.content, message_id: message.id)}</div>
+                  <div class="prose prose-sm max-w-none message-content">
+                    {Markdown.to_html(message.content, message_id: Map.get(message, :id))}
+                  </div>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
  - Normal click: copies code with output as comments
  - Shift+click: copies clean code only (strips prompts/output)
  - Hover tooltip shows shift-click option
  - Handles IEx prompts, continuation lines, and output detection
  - Fix: Handle messages without IDs during streaming

  🤖 Generated with Claude Code